### PR TITLE
tweak regexes

### DIFF
--- a/chuse
+++ b/chuse
@@ -186,8 +186,8 @@ def parse_atom(atom: "A raw atom as a string") -> "The atom parts as a dict":
     parts = ['selector', 'cat', 'pkg', 'version', 'slot']
     selector_ptrn = r'(?P<selector>>=|<=|<|=|>)'
     cat_ptrn = r'(?P<cat>[a-z0-9]+(-[a-z0-9]+)?)'
-    pkg_ptrn = r'(?P<pkg>[a-z0-9]+(-[a-z0-9]+)*)'
-    version_ptrn = r'(?P<version>[0-9]+(\.[0-9]+)*(-r[0-9]+)?)'
+    pkg_ptrn = r'(?P<pkg>[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\+?)'
+    version_ptrn = r'(?P<version>[0-9]+(\.[0-9]+)*(_[a-zA-Z]+)?([0-9]+)?(-r[0-9]+)?[a-z]?)'
     slot_ptrn = r'(?P<slot>.*)'
 
     pattern = '^' + selector_ptrn + '?' + cat_ptrn + '/' + pkg_ptrn + \


### PR DESCRIPTION
Some packages (for example:

```
dev-libs/libcdio-paranoia-0.90_p1-r1
dev-libs/openssl-1.0.1m
media-libs/libcaca-0.99_beta18-r2
media-libs/speex-1.2_rc1-r2
x11-libs/gtk+
```

) were not being recognized in my package.use.
